### PR TITLE
remove jquery from dep list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8931,11 +8931,6 @@
         "supports-color": "^7.0.0"
       }
     },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "bootstrap": "^4.6.0",
     "core-js": "^3.9.1",
     "font-awesome": "^4.7.0",
-    "jquery": "^3.6.0",
     "ng-push-ivy": "^1.0.8",
     "ng-socket-io": "^0.2.4",
     "ngx-clipboard": "^14.0.1",


### PR DESCRIPTION
`jquery` does not seem to be used in this project.  It is used by the [Console.Ui](https://github.com/cmu-sei/Console.Ui) for VMWare but that seems to be the extent of it.  In order to confirm it's no longer needed, I did the following:

- Installed and ran `npm-check` which reported it not being used
- Removed and tested
  - Ran `npm uninstall jquery`
  - Deleted all `node_modules`
  - Ran `npm i` with no errors
  - Ran `ng build --prod` with no errors