### PR TITLE
added mini and resizable application sidenav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@mdi/font": "^7.2.96",
         "@microsoft/signalr": "^6.0.0",
         "@popperjs/core": "^2.10.2",
+        "angular-resizable-element": "^7.0.2",
         "babel-polyfill": "^6.26.0",
         "bootstrap": "^5.2.3",
         "core-js": "^3.18.3",
@@ -6017,6 +6018,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/angular-resizable-element": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/angular-resizable-element/-/angular-resizable-element-7.0.2.tgz",
+      "integrity": "sha512-/BGuNiA38n9klexHO1xgnsA3VYigj9v+jUGjKtBRgfB26bCxZKsNWParSu2k3EqbATrfAJC4Nl8f7cORpJFf4w==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=15.0.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "dev": true,
@@ -9162,9 +9174,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
-      "license": "MIT"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -21435,6 +21451,14 @@
       "dev": true,
       "requires": {}
     },
+    "angular-resizable-element": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/angular-resizable-element/-/angular-resizable-element-7.0.2.tgz",
+      "integrity": "sha512-/BGuNiA38n9klexHO1xgnsA3VYigj9v+jUGjKtBRgfB26bCxZKsNWParSu2k3EqbATrfAJC4Nl8f7cORpJFf4w==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
     "ansi-colors": {
       "version": "4.1.3",
       "dev": true
@@ -23642,7 +23666,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "functions-have-names": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@mdi/font": "^7.2.96",
     "@microsoft/signalr": "^6.0.0",
     "@popperjs/core": "^2.10.2",
+    "angular-resizable-element": "^7.0.2",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^5.2.3",
     "core-js": "^3.18.3",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -102,6 +102,7 @@ import { TableVirtualScrollModule } from 'ng-table-virtual-scroll';
 import { AppAdminSubscriptionSearchComponent } from './components/admin-app/app-admin-subscription-search/app-admin-subscription-search.component';
 import { EditSubscriptionComponent } from './components/admin-app/app-admin-subscription-search/edit-subscription/edit-subscription.component';
 import { CreateApplicationDialogComponent } from './components/shared/create-application-dialog/create-application-dialog.component';
+import { ResizableModule } from 'angular-resizable-element';
 
 @NgModule({
   exports: [
@@ -206,6 +207,7 @@ export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {
     ComnSettingsModule.forRoot(),
     ComnAuthModule.forRoot(),
     TableVirtualScrollModule,
+    ResizableModule,
   ],
   providers: [
     AppService,

--- a/src/app/components/player/application-list/application-list.component.html
+++ b/src/app/components/player/application-list/application-list.component.html
@@ -21,7 +21,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           mat-button
           [title]="app.name"
           class="px-0 w-100"
-          [href]="insertThemeToUrl(app.url)"
+          [href]="app.themedUrl"
           (click)="
             $event.preventDefault();
             app.embeddable ? openInFocusedApp(app) : openInTab(app)

--- a/src/app/components/player/application-list/application-list.component.html
+++ b/src/app/components/player/application-list/application-list.component.html
@@ -7,7 +7,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   <mat-list class="appitems-container">
     <mat-list-item
       *ngFor="let app of applications$ | async; trackBy: trackByFn"
-      class=""
+      [ngClass]="mini ? 'list-item-mini' : 'list-item'"
     >
       <iframe
         *ngIf="app.loadInBackground"
@@ -17,19 +17,28 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       ></iframe>
 
       <div class="app-button-container">
-        <button
+        <a
           mat-button
+          [title]="app.name"
           class="px-0 w-100"
-          (click)="app.embeddable ? openInFocusedApp(app) : openInTab(app)"
+          [href]="insertThemeToUrl(app.url)"
+          (click)="
+            $event.preventDefault();
+            app.embeddable ? openInFocusedApp(app) : openInTab(app)
+          "
         >
-          <div class="d-flex align-items-center">
+          <div
+            class="d-flex align-items-center"
+            [ngClass]="mini ? 'justify-content-center' : null"
+          >
             <img class="lefticon" src="{{ app.icon }}" alt="{{ app.name }}" />
-            <div>
+            <div *ngIf="!mini" class="app-name ps-2">
               {{ app.name }}
             </div>
           </div>
-        </button>
+        </a>
         <button
+          *ngIf="!mini"
           mat-icon-button
           [matMenuTriggerFor]="menu"
           aria-label="{{ app.name }} Menu"

--- a/src/app/components/player/application-list/application-list.component.scss
+++ b/src/app/components/player/application-list/application-list.component.scss
@@ -30,7 +30,6 @@
 .lefticon {
   font-size: 75%;
   padding: 0.5em;
-  padding-right: 1.5em;
   height: 35px;
   text-align: center;
 }
@@ -40,4 +39,18 @@
   align-items: center;
   justify-content: center;
   width: 100%;
+}
+
+::ng-deep .list-item-mini > .mat-list-item-content {
+  padding: 0 !important;
+}
+
+::ng-deep .list-item > .mat-list-item-content {
+  padding-left: 16px !important;
+  padding-right: 0px !important;
+}
+
+.app-name {
+  width: 100%;
+  text-wrap: pretty;
 }

--- a/src/app/components/player/application-list/application-list.component.ts
+++ b/src/app/components/player/application-list/application-list.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ComnAuthQuery, ComnAuthService, Theme } from '@cmusei/crucible-common';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, combineLatest } from 'rxjs';
 import { map, takeUntil, tap } from 'rxjs/operators';
 import { ApplicationData } from '../../../models/application-data';
 import { TeamData } from '../../../models/team-data';
@@ -34,7 +34,6 @@ export class ApplicationListComponent implements OnInit, OnChanges, OnDestroy {
   public viewGUID: string;
   public titleText: string;
   private unsubscribe$: Subject<null> = new Subject<null>();
-  private currentTheme = Theme.LIGHT;
   private currentApp: ApplicationData;
 
   constructor(
@@ -43,11 +42,7 @@ export class ApplicationListComponent implements OnInit, OnChanges, OnDestroy {
     private authService: ComnAuthService,
     private sanitizer: DomSanitizer,
     private authQuery: ComnAuthQuery
-  ) {
-    authQuery.userTheme$
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe((t) => (this.currentTheme = t));
-  }
+  ) {}
 
   ngOnInit() {
     this.refreshApps();
@@ -61,33 +56,34 @@ export class ApplicationListComponent implements OnInit, OnChanges, OnDestroy {
 
   // Local Component functions
   openInTab(app: ApplicationData) {
-    const url = this.insertThemeToUrl(app.url);
-    window.open(url, '_blank');
+    window.open(app.themedUrl, '_blank');
   }
 
   refreshApps() {
-    this.applications$ = this.applicationsService
-      .getApplicationsByTeam(this.teams.find((t) => t.isPrimary).id)
-      .pipe(
-        map((apps) => ({ apps })),
-        map(({ apps }) => {
-          apps.forEach(
-            (app) =>
-              (app.safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
-                app.url
-              ))
+    this.applications$ = combineLatest([
+      this.authQuery.userTheme$,
+      this.applicationsService.getApplicationsByTeam(
+        this.teams.find((t) => t.isPrimary).id
+      ),
+    ]).pipe(
+      map(([theme, apps]) => {
+        apps.forEach((app) => {
+          app.themedUrl = this.insertThemeToUrl(app.url, theme);
+          app.safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
+            app.themedUrl
           );
-          return apps;
-        }),
-        tap((apps) => {
-          if (apps.length > 0) {
-            this.currentApp === undefined
-              ? this.openInFocusedApp(apps[0])
-              : this.openInFocusedApp(this.currentApp);
-          }
-        }),
-        takeUntil(this.unsubscribe$)
-      );
+        });
+        return apps;
+      }),
+      tap((apps) => {
+        if (apps.length > 0) {
+          this.currentApp === undefined
+            ? this.openInFocusedApp(apps[0])
+            : this.openInFocusedApp(this.currentApp);
+        }
+      }),
+      takeUntil(this.unsubscribe$)
+    );
   }
 
   openInFocusedApp(app: ApplicationData) {
@@ -99,20 +95,19 @@ export class ApplicationListComponent implements OnInit, OnChanges, OnDestroy {
         );
         window.location.reload();
       } else {
-        const url = this.insertThemeToUrl(app.url);
-        this.focusedAppService.focusedAppUrl.next(url);
+        this.focusedAppService.focusedAppUrl.next(app.themedUrl);
       }
     });
   }
 
-  insertThemeToUrl(url: string) {
+  insertThemeToUrl(url: string, theme: Theme) {
     if (url.includes('{theme}')) {
       if (url.includes('?')) {
-        url = url.replace('?{theme}', '?theme=' + this.currentTheme);
-        url = url.replace('&{theme}', '&theme=' + this.currentTheme);
-        url = url.replace('{theme}', '&theme=' + this.currentTheme);
+        url = url.replace('?{theme}', '?theme=' + theme);
+        url = url.replace('&{theme}', '&theme=' + theme);
+        url = url.replace('{theme}', '&theme=' + theme);
       } else {
-        url = url.replace('{theme}', '?theme=' + this.currentTheme);
+        url = url.replace('{theme}', '?theme=' + theme);
       }
     }
     return url;

--- a/src/app/components/player/application-list/application-list.component.ts
+++ b/src/app/components/player/application-list/application-list.component.ts
@@ -28,6 +28,7 @@ import { FocusedAppService } from '../../../services/focused-app/focused-app.ser
 export class ApplicationListComponent implements OnInit, OnChanges, OnDestroy {
   @Input() viewId: string;
   @Input() teams: TeamData[];
+  @Input() mini: boolean;
 
   public applications$: Observable<ApplicationData[]>;
   public viewGUID: string;

--- a/src/app/components/player/player.component.html
+++ b/src/app/components/player/player.component.html
@@ -5,43 +5,68 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 
 <ng-container *ngIf="data$ | async as data; else loading">
   <ng-container *ngIf="loaded" ; else loading>
-    <mat-sidenav-container class="appcontent-container" autosize>
+    <mat-sidenav-container
+      class="appcontent-container"
+      [autosize]="autosizeSidenav"
+    >
       <mat-sidenav
         #sidenav
         class="appbarmenu-container"
         mode="side"
         [opened]="opened$ | async"
+        mwlResizable
+        (resizing)="resizingFn($event)"
+        (resizeEnd)="resizeEnd($event)"
+        [ngStyle]="resizeStyle"
       >
-        <mat-list class="appitems-container">
-          <mat-list-item>
-            <a class="nolink" [routerLink]="['/']">
-              <div class="d-flex align-items-center">
-                <mat-icon
-                  class="player-icon"
-                  svgIcon="ic_crucible_player"
-                ></mat-icon>
-                <h2>
-                  <b>{{ data.title }}</b>
-                </h2>
-              </div>
-            </a>
+        <div class="grid">
+          <div>
+            <mat-list>
+              <mat-list-item
+                class="d-flex"
+                [ngClass]="
+                  (mini$ | async) ? 'player-title-mini' : 'player-title'
+                "
+              >
+                <a class="nolink" [routerLink]="['/']">
+                  <div class="d-flex align-items-center">
+                    <mat-icon
+                      [ngClass]="
+                        (mini$ | async) ? 'player-icon-mini' : 'player-icon'
+                      "
+                      svgIcon="ic_crucible_player"
+                    ></mat-icon>
+                    <h2 *ngIf="!(mini$ | async)">
+                      <b>{{ data.title }}</b>
+                    </h2>
+                  </div>
+                </a>
+              </mat-list-item>
+            </mat-list>
             <mat-divider></mat-divider>
-          </mat-list-item>
-        </mat-list>
-        <app-application-list
-          [viewId]="data.view.id"
-          [teams]="data.teams"
-          (toggleSideNavEvent)="sidenavToggleFn()"
-        ></app-application-list>
-        <img
-          alt="crucible logo"
-          class="crucible-logo"
-          [src]="
-            (theme$ | async) === 'light-theme'
-              ? 'assets/img/crucible-logo-light.png'
-              : 'assets/img/crucible-logo-dark.png'
-          "
-        />
+            <app-application-list
+              [viewId]="data.view.id"
+              [teams]="data.teams"
+              [mini]="mini$ | async"
+            ></app-application-list>
+            <img
+              *ngIf="!(mini$ | async)"
+              alt="crucible logo"
+              class="crucible-logo"
+              [src]="
+                (theme$ | async) === 'light-theme'
+                  ? 'assets/img/crucible-logo-light.png'
+                  : 'assets/img/crucible-logo-dark.png'
+              "
+            />
+          </div>
+          <div
+            *ngIf="!(mini$ | async)"
+            class="resize-handle-right"
+            mwlResizeHandle
+            [resizeEdges]="{ right: true }"
+          ></div>
+        </div>
       </mat-sidenav>
       <mat-sidenav-content class="noscroll">
         <app-topbar
@@ -52,6 +77,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           [teams]="data.teams"
           [team]="data.team"
           [viewId]="viewId"
+          [mini]="mini$ | async"
           (setTeam)="setPrimaryTeam($event)"
           (sidenavToggle)="sidenavToggleFn($event)"
           (editView)="editViewFn($event)"

--- a/src/app/components/player/player.component.scss
+++ b/src/app/components/player/player.component.scss
@@ -15,11 +15,16 @@
 
 .appbarmenu-container {
   min-width: 50px;
+  max-width: 20vw;
 }
 
 .player-icon {
   transform: scale(2);
   width: 60px;
+}
+
+.player-icon-mini {
+  transform: scale(2);
 }
 
 .crucible-logo {
@@ -46,18 +51,6 @@
 
 .nolink {
   text-decoration: none;
-  position: absolute;
-  left: 0px;
-}
-
-.display {
-  position: absolute;
-  left: 80px;
-  top: 10px;
-}
-
-.expand {
-  margin-top: -2px;
 }
 
 .view-text {
@@ -68,4 +61,26 @@
 .team-text {
   text-align: right;
   margin-right: 10px;
+}
+
+::ng-deep .player-title > .mat-list-item-content {
+  padding: 0 !important;
+}
+
+.player-title-mini {
+  justify-content: center;
+}
+
+.resize-handle-right {
+  height: 100%;
+  cursor: col-resize;
+  width: 10px;
+  position: relative;
+  right: 10px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 0px;
+  height: 100%;
 }

--- a/src/app/components/player/player.component.ts
+++ b/src/app/components/player/player.component.ts
@@ -88,7 +88,7 @@ export class PlayerComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.data$ = this.checkParam(['teamId', 'opened']).pipe(
+    this.data$ = this.checkParam(['teamId']).pipe(
       tap((paramsExist) =>
         paramsExist ? (this.loaded = true) : (this.loaded = false)
       ),

--- a/src/app/components/shared/top-bar/topbar.component.html
+++ b/src/app/components/shared/top-bar/topbar.component.html
@@ -114,6 +114,13 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         >
           Administration
         </a>
+        <button
+          *ngIf="topbarView === 'player-player'"
+          mat-menu-item
+          (click)="resetUI()"
+        >
+          Reset UI
+        </button>
         <a
           *ngIf="topbarView === 'player-player'"
           [routerLink]="['/']"

--- a/src/app/components/shared/top-bar/topbar.component.scss
+++ b/src/app/components/shared/top-bar/topbar.component.scss
@@ -33,9 +33,3 @@
   font-size: large;
   font-weight: bold;
 }
-a {
-  &:hover,
-  &:focus {
-    color: var(--mat-app-text-color);
-  }
-}

--- a/src/app/components/shared/top-bar/topbar.component.ts
+++ b/src/app/components/shared/top-bar/topbar.component.ts
@@ -21,6 +21,7 @@ import { LoggedInUserService } from '../../../services/logged-in-user/logged-in-
 import { UserPresenceComponent } from '../../player/user-presence-page/user-presence/user-presence.component';
 import { TopbarView } from './topbar.models';
 import { Router } from '@angular/router';
+import { DialogService } from '../../../services/dialog/dialog.service';
 @Component({
   selector: 'app-topbar',
   templateUrl: './topbar.component.html',
@@ -36,6 +37,7 @@ export class TopbarComponent implements OnInit, OnDestroy {
   @Input() topbarTextColor?;
   @Input() topbarView?: TopbarView;
   @Input() viewId: string;
+  @Input() mini: boolean;
   @Output() sidenavToggle?: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() setTeam?: EventEmitter<string> = new EventEmitter<string>();
   @Output() editView?: EventEmitter<any> = new EventEmitter<any>();
@@ -52,7 +54,8 @@ export class TopbarComponent implements OnInit, OnDestroy {
     private loggedInUserService: LoggedInUserService,
     private authQuery: ComnAuthQuery,
     private router: Router,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private dialogService: DialogService
   ) {}
 
   ngOnInit() {
@@ -115,6 +118,20 @@ export class TopbarComponent implements OnInit, OnDestroy {
         },
       })
     );
+  }
+
+  resetUI() {
+    this.dialogService
+      .confirm(
+        'Reset UI?',
+        `Are you sure that you want to reset your UI preferences for the ${this.team.name} Team?`
+      )
+      .subscribe((result) => {
+        if (result['confirm']) {
+          localStorage.removeItem(this.team.id);
+          window.location.reload();
+        }
+      });
   }
 
   ngOnDestroy(): void {

--- a/src/app/models/application-data.ts
+++ b/src/app/models/application-data.ts
@@ -14,4 +14,5 @@ export interface ApplicationData {
   loadInBackground: boolean;
   viewId: string;
   safeUrl: SafeUrl;
+  themedUrl: string;
 }

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -171,10 +171,6 @@ $custom-typography: mat.define-legacy-typography-config(
 
   a {
     color: map-get($foreground, text);
-    &:hover,
-    &:focus {
-      color: map-get($foreground, disabled);
-    }
   }
 
   .mat-column-online,


### PR DESCRIPTION
- collapsing sidenav now has 2 modes
  - first collapse shows icons only
  - second collapse closes sidenav
- sidenav is now resizable
- sidenav preferences are saved to local storage on a per team basis
  - added a new menu item to reset saved ui preferences
- application buttons are now links that can be opened in new tabs natively