### PR TITLE
Fix view deletion redirect and add error handling for deleted views

### DIFF
--- a/src/app/components/admin-app/admin-view-search/admin-view-edit/admin-view-edit.component.ts
+++ b/src/app/components/admin-app/admin-view-search/admin-view-edit/admin-view-edit.component.ts
@@ -270,7 +270,7 @@ export class AdminViewEditComponent implements OnInit {
             .pipe(take(1))
             .subscribe(() => {
               console.log('successfully deleted view');
-              this.returnToViewSearch();
+              this.editComplete.emit(null);
             });
         }
       });

--- a/src/app/components/admin-app/admin-view-search/admin-view-search.component.ts
+++ b/src/app/components/admin-app/admin-view-search/admin-view-search.component.ts
@@ -191,6 +191,16 @@ export class AdminViewSearchComponent implements OnInit {
   }
 
   onEditComplete($event) {
+    // Clear the view query parameter if it exists
+    const viewParam = this.route.snapshot.queryParamMap.get('view');
+    if (viewParam) {
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { view: null },
+        queryParamsHandling: 'merge'
+      });
+    }
+
     this.refreshViews();
 
     // if (this.loggedInUserService.isSuperUser$.getValue()) {

--- a/src/app/components/player/player.component.ts
+++ b/src/app/components/player/player.component.ts
@@ -142,6 +142,15 @@ export class PlayerComponent implements OnInit, OnDestroy {
             team: teams.find((t) => t.isPrimary),
             title: this.settingsService.settings.AppTitle,
           })),
+          catchError((error) => {
+            // If the view doesn't exist (404) or another error occurs, redirect to home
+            this.messageService.displayMessage(
+              'View Not Found',
+              'The view you are trying to access no longer exists or you do not have permission to access it.',
+            );
+            this.router.navigate(['/']);
+            return EMPTY;
+          }),
         ),
       ),
       tap(({ teams, team }) => {
@@ -209,8 +218,12 @@ export class PlayerComponent implements OnInit, OnDestroy {
           dialogRef.componentInstance.setView(data.view);
         }
       });
-      dialogRef.componentInstance.editComplete.subscribe(() => {
+      dialogRef.componentInstance.editComplete.subscribe((viewId) => {
         dialogRef.close();
+        // If viewId is null, the view was deleted - navigate to home page
+        if (viewId === null) {
+          this.router.navigate(['/']);
+        }
       });
     }
   }


### PR DESCRIPTION
When a user deletes a view, they should be redirected away from that view since it no longer exists. This fix ensures proper navigation in all scenarios:

Changes:
- admin-view-edit.component.ts: Emit null when view is deleted to signal deletion event instead of just closing the edit screen
- admin-view-search.component.ts: Clear 'view' query parameter from URL when returning from edit to prevent stale URLs
- player.component.ts: Added error handling to catch 404 when loading a deleted view and redirect to home page with user-friendly message
- player.component.ts: Navigate to home page when view is deleted from within the player view dialog

Behavior for users in other browsers:
- If they refresh the page, the API call to load the view will fail (404)
- The error handler catches this and shows: "View Not Found - The view you are trying to access no longer exists or you do not have permission to access it"
- They are automatically redirected to the home page
- If they don't refresh, their session continues until they navigate away or refresh the page