### PR TITLE
Fix header-text color for dark mode globally

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -56,6 +56,7 @@ body {
 
 .header-text {
   font-family: open_sansbold;
+  color: var(--mat-sys-on-surface);
 }
 
 /* Fix user dropdown menu scrollbar */


### PR DESCRIPTION
Was noticed in the Edit View dialog during dark mode.