### PR TITLE
Fix/admin search styling and update default team tooltip text

### DIFF
--- a/src/app/components/admin-app/admin-app-template-search/admin-app-template-search.component.html
+++ b/src/app/components/admin-app/admin-app-template-search/admin-app-template-search.component.html
@@ -17,11 +17,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
     </div>
     <div class="my-1">
       <mat-form-field style="width: 250px" subscriptSizing="dynamic">
-        <mat-icon
-          matPrefix
-          style="transform: scale(0.85); margin-right: 5px"
-          svgIcon="ic_magnify_search"
-        ></mat-icon>
         <input
           matInput
           [(ngModel)]="filterString"
@@ -32,6 +27,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           <button
             mat-icon-button
             matSuffix
+            color="primary"
             (click)="clearFilter()"
             title="Clear Search"
           >

--- a/src/app/components/admin-app/admin-user-search/admin-user-search.component.html
+++ b/src/app/components/admin-app/admin-user-search/admin-user-search.component.html
@@ -10,7 +10,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   <mat-form-field style="width: 300px">
     <input matInput [(ngModel)]="filterString" (keyup)="applyFilter($event.target.value)" placeholder="Search" />
     @if (filterString) {
-    <button mat-icon-button matSuffix (click)="applyFilter('')" title="Clear Search">
+    <button mat-icon-button matSuffix color="primary" (click)="applyFilter('')" title="Clear Search">
       <mat-icon style="transform: scale(0.85)" fontIcon="mdi-close-circle-outline"></mat-icon>
     </button>
     }

--- a/src/app/components/admin-app/admin-view-search/admin-view-edit/admin-view-edit.component.html
+++ b/src/app/components/admin-app/admin-view-search/admin-view-edit/admin-view-edit.component.html
@@ -229,7 +229,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
                                   : null
                               )
                             "
-                            matTooltip="If this is the default Team of the View"
+                            matTooltip="Users will be assigned to this team when deployed as an on-demand event"
                           >
                             Default
                           </mat-checkbox>

--- a/src/app/components/admin-app/admin-view-search/admin-view-search.component.html
+++ b/src/app/components/admin-app/admin-view-search/admin-view-search.component.html
@@ -17,11 +17,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
     <h3 class="header-text ms-2">Views</h3>
     <div class="ms-5">
       <mat-form-field style="width: 320px" subscriptSizing="dynamic">
-        <mat-icon
-          matPrefix
-          style="transform: scale(0.85); margin-right: 5px"
-          svgIcon="ic_magnify_search"
-        ></mat-icon>
         <input
           matInput
           [(ngModel)]="filterString"
@@ -32,6 +27,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           <button
             mat-icon-button
             matSuffix
+            color="primary"
             (click)="clearFilter()"
             title="Clear Search"
           >
@@ -123,7 +119,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 
     <!-- Description Column -->
     <ng-container matColumnDef="description">
-      <mat-header-cell *matHeaderCellDef> Description </mat-header-cell>
+      <mat-header-cell *matHeaderCellDef mat-sort-header> Description </mat-header-cell>
       <mat-cell *matCellDef="let element">
         <div class="description-text" style="margin: 5px">
           {{ element.description }}

--- a/src/app/components/admin-app/app-admin-subscription-search/app-admin-subscription-search.component.html
+++ b/src/app/components/admin-app/app-admin-subscription-search/app-admin-subscription-search.component.html
@@ -14,11 +14,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
     <h3 class="header-text ms-2">Subscriptions</h3>
     <div class="d-flex align-items-center ms-4">
       <mat-form-field style="width: 320px" subscriptSizing="dynamic">
-        <mat-icon
-          matPrefix
-          style="transform: scale(0.85); margin-right: 5px"
-          svgIcon="ic_magnify_search"
-        ></mat-icon>
         <input
           matInput
           [(ngModel)]="filterStr"
@@ -29,6 +24,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           <button
             mat-icon-button
             matSuffix
+            color="primary"
             (click)="clearFilter()"
             title="Clear Search"
           >

--- a/src/assets/svg-icons/ic_cancel_circle.svg
+++ b/src/assets/svg-icons/ic_cancel_circle.svg
@@ -1,4 +1,4 @@
-<svg fill="#d3d3d3" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">
+<svg fill="currentColor" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">
 <path d="M16 0c-8.837 0-16 7.163-16 16s7.163 16 16 16 16-7.163 16-16-7.163-16-16-16zM16 29c-7.18 0-13-5.82-13-13s5.82-13 13-13 13 5.82 13 13-5.82 13-13 13z"></path>
 <path d="M21 8l-5 5-5-5-3 3 5 5-5 5 3 3 5-5 5 5 3-3-5-5 5-5z"></path>
 </svg>


### PR DESCRIPTION
## Summary
  - Standardize admin search field styling across all admin pages (Views, Application Templates, Users, Subscriptions)
  - Add primary theme color to clear buttons
  - Update ic_cancel_circle SVG to use currentColor for proper theme support
  - Remove magnifying glass icons for consistent design across applications
  - Make description column sortable in admin views page
  - Improve default team tooltip to clarify it's for on-demand event user assignment