### PR TITLE
Add team management for ManageTeam users

### DIFF
--- a/src/app/components/player/manage-teams/manage-teams.component.html
+++ b/src/app/components/player/manage-teams/manage-teams.component.html
@@ -25,37 +25,27 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       You do not have permission to manage any Teams in this View.
     </mat-card>
   } @else {
-    <mat-accordion>
+    <mat-action-list>
       @for (teamContainer of teams(); track teamContainer.team.id) {
-        <mat-expansion-panel>
-          <mat-expansion-panel-header>
-            <mat-panel-title>{{ teamContainer.team.name }}</mat-panel-title>
-          </mat-expansion-panel-header>
-          <div class="d-flex flex-column align-items-center">
-            <button
-              mat-button
-              (click)="openUsersDialog(teamContainer.team)"
-              title="Add or remove users for this team"
-            >
-              <span
-                class="d-inline-block"
-                [matBadge]="teamContainer.userCount"
-                [matBadgeHidden]="teamContainer.userCount === null"
-                matBadgePosition="above after"
-                matBadgeColor="accent"
-              >
-                <img
-                  class="left-icon"
-                  src="assets/img/SP_Icon_User.png"
-                  alt="Users"
-                />
-              </span>
-            </button>
-            <span>Users</span>
-          </div>
-        </mat-expansion-panel>
+        <button
+          mat-list-item
+          (click)="openUsersDialog(teamContainer.team)"
+          [attr.title]="'Add or remove users for ' + teamContainer.team.name"
+        >
+          <span matListItemTitle>{{ teamContainer.team.name }}</span>
+          @if (teamContainer.userCount !== null) {
+            <span matListItemMeta class="d-flex align-items-center gap-1">
+              <img
+                class="left-icon"
+                src="assets/img/SP_Icon_User.png"
+                alt="Users"
+              />
+              {{ teamContainer.userCount }}
+            </span>
+          }
+        </button>
       }
-    </mat-accordion>
+    </mat-action-list>
   }
 </mat-dialog-content>
 

--- a/src/app/components/player/manage-teams/manage-teams.component.html
+++ b/src/app/components/player/manage-teams/manage-teams.component.html
@@ -1,0 +1,64 @@
+<!--
+Copyright 2025 Carnegie Mellon University. All Rights Reserved.
+Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+-->
+
+<h4 mat-dialog-title>Manage Teams: {{ view()?.name }}</h4>
+
+<mat-dialog-content class="manage-teams-content">
+  @if (teamsResource.isLoading() && !teamsResource.hasValue()) {
+    <mat-card
+      appearance="outlined"
+      class="d-flex justify-content-center align-items-center"
+    >
+      <mat-progress-spinner
+        color="primary"
+        mode="indeterminate"
+      ></mat-progress-spinner>
+    </mat-card>
+  } @else if (teamsResource.error()) {
+    <mat-card appearance="outlined" class="empty-state">
+      Unable to load teams. Please try again.
+    </mat-card>
+  } @else if (teams().length === 0) {
+    <mat-card appearance="outlined" class="empty-state">
+      You do not have permission to manage any Teams in this View.
+    </mat-card>
+  } @else {
+    <mat-accordion>
+      @for (teamContainer of teams(); track teamContainer.team.id) {
+        <mat-expansion-panel>
+          <mat-expansion-panel-header>
+            <mat-panel-title>{{ teamContainer.team.name }}</mat-panel-title>
+          </mat-expansion-panel-header>
+          <div class="d-flex flex-column align-items-center">
+            <button
+              mat-button
+              (click)="openUsersDialog(teamContainer.team)"
+              title="Add or remove users for this team"
+            >
+              <span
+                class="d-inline-block"
+                [matBadge]="teamContainer.userCount"
+                [matBadgeHidden]="teamContainer.userCount === null"
+                matBadgePosition="above after"
+                matBadgeColor="accent"
+              >
+                <img
+                  class="left-icon"
+                  src="assets/img/SP_Icon_User.png"
+                  alt="Users"
+                />
+              </span>
+            </button>
+            <span>Users</span>
+          </div>
+        </mat-expansion-panel>
+      }
+    </mat-accordion>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions class="justify-content-center">
+  <button mat-stroked-button mat-dialog-close>Done</button>
+</mat-dialog-actions>

--- a/src/app/components/player/manage-teams/manage-teams.component.scss
+++ b/src/app/components/player/manage-teams/manage-teams.component.scss
@@ -1,0 +1,30 @@
+// Copyright 2025 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+@use '@angular/material' as mat;
+
+:host {
+  // Material M3 sets dialog-with-actions content padding to `20px 24px 0` (zero
+  // bottom), expecting the actions bar to supply the bottom gap. With the content
+  // area scrolling (max-height: 65vh), the last team panel sits flush against the
+  // actions bar and looks cut off. Restore a bottom value via the design token.
+  @include mat.dialog-overrides(
+    (
+      with-actions-content-padding: 20px 24px 20px,
+    )
+  );
+}
+
+.manage-teams-content {
+  min-width: 400px;
+}
+
+.empty-state {
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.left-icon {
+  height: 30px;
+  width: 30px;
+}

--- a/src/app/components/player/manage-teams/manage-teams.component.ts
+++ b/src/app/components/player/manage-teams/manage-teams.component.ts
@@ -4,12 +4,11 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, inject } from '@angular/core';
 import { rxResource, toSignal } from '@angular/core/rxjs-interop';
-import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
-import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { forkJoin, of } from 'rxjs';
@@ -39,12 +38,11 @@ interface ManageableTeam {
   styleUrls: ['./manage-teams.component.scss'],
   imports: [
     CommonModule,
-    MatBadgeModule,
     MatButtonModule,
     MatCardModule,
     MatDialogModule,
-    MatExpansionModule,
     MatIconModule,
+    MatListModule,
     MatProgressSpinnerModule,
   ],
 })
@@ -118,7 +116,7 @@ export class ManageTeamsComponent {
       .addRemoveUsersToTeam(
         'Add or Remove Users for team ' + team.name,
         team,
-        { maxWidth: '100vw', width: 'auto' },
+        { maxWidth: '100vw', width: 'auto', restoreFocus: false },
         false,
       )
       // Member counts came from getTeamUsers at load; refresh them after the

--- a/src/app/components/player/manage-teams/manage-teams.component.ts
+++ b/src/app/components/player/manage-teams/manage-teams.component.ts
@@ -1,0 +1,128 @@
+// Copyright 2025 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject } from '@angular/core';
+import { rxResource, toSignal } from '@angular/core/rxjs-interop';
+import { MatBadgeModule } from '@angular/material/badge';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { forkJoin, of } from 'rxjs';
+import {
+  Team,
+  TeamService,
+  UserService,
+  ViewService,
+} from '../../../generated/player-api';
+import { DialogService } from '../../../services/dialog/dialog.service';
+import { UserPermissionsService } from '../../../services/permissions/user-permissions.service';
+
+/** Data passed to the dialog when opened. */
+export interface ManageTeamsDialogData {
+  viewId: string;
+}
+
+/** A team the current user can manage along with its member count (null if unknown). */
+interface ManageableTeam {
+  team: Team;
+  userCount: number | null;
+}
+
+@Component({
+  selector: 'app-manage-teams',
+  templateUrl: './manage-teams.component.html',
+  styleUrls: ['./manage-teams.component.scss'],
+  imports: [
+    CommonModule,
+    MatBadgeModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDialogModule,
+    MatExpansionModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+  ],
+})
+export class ManageTeamsComponent {
+  private readonly data = inject<ManageTeamsDialogData>(MAT_DIALOG_DATA);
+  private readonly viewService = inject(ViewService);
+  private readonly teamService = inject(TeamService);
+  private readonly userService = inject(UserService);
+  private readonly dialogService = inject(DialogService);
+  private readonly permissionsService = inject(UserPermissionsService);
+
+  private readonly viewId = this.data.viewId;
+
+  // Dialog title. catchError so a failed title fetch can't throw on signal read
+  // (the template uses view()?.name).
+  protected readonly view = toSignal(
+    this.viewService.getView(this.viewId).pipe(catchError(() => of(null))),
+  );
+
+  // Teams the user can manage, with member counts. Loads team-permission claims
+  // FIRST and derives the manageable ids from them, so there is no race against a
+  // seeded-empty permission stream. Teams are filtered to manageable ones BEFORE
+  // fetching user counts, so getTeamUsers is never called on a team the user lacks
+  // ViewTeam/ManageTeam on (which would 403). rxResource captures any stream error
+  // into error() rather than throwing on read, and reload() refreshes counts.
+  protected readonly teamsResource = rxResource({
+    stream: () =>
+      this.permissionsService
+        .loadTeamPermissions(this.viewId, undefined, true)
+        .pipe(
+          switchMap((claims) => {
+            const manageableIds =
+              this.permissionsService.getManageableTeamIds(claims);
+            return this.teamService.getMyViewTeams(this.viewId).pipe(
+              switchMap((teams) => {
+                const manageable = teams.filter(
+                  (t): t is Team & { id: string } =>
+                    !!t.id && t.isMember && manageableIds.includes(t.id),
+                );
+                if (manageable.length === 0) {
+                  return of([] as ManageableTeam[]);
+                }
+                return forkJoin(
+                  manageable.map((team) =>
+                    this.userService.getTeamUsers(team.id).pipe(
+                      map((users) => ({ team, userCount: users.length })),
+                      // ManageTeam does not imply ViewTeam, so getTeamUsers may
+                      // 403 if the custom role lacks ViewTeam. Degrade to no count
+                      // rather than failing the whole stream.
+                      catchError(() =>
+                        of({ team, userCount: null as number | null }),
+                      ),
+                    ),
+                  ),
+                );
+              }),
+            );
+          }),
+        ),
+  });
+
+  protected readonly teams = computed<ManageableTeam[]>(() =>
+    (this.teamsResource.value() ?? [])
+      .slice()
+      .sort((a, b) => (a.team.name ?? '').localeCompare(b.team.name ?? '')),
+  );
+
+  /** Opens the add/remove users dialog in restricted (ManageTeam) mode. */
+  openUsersDialog(team: Team): void {
+    this.dialogService
+      .addRemoveUsersToTeam(
+        'Add or Remove Users for team ' + team.name,
+        team,
+        { maxWidth: '100vw', width: 'auto' },
+        false,
+      )
+      // Member counts came from getTeamUsers at load; refresh them after the
+      // user adds/removes members so the badges stay accurate.
+      .subscribe(() => this.teamsResource.reload());
+  }
+}

--- a/src/app/components/shared/add-remove-users-dialog/add-remove-users-dialog.component.html
+++ b/src/app/components/shared/add-remove-users-dialog/add-remove-users-dialog.component.html
@@ -77,11 +77,13 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
             <mat-icon class="mdi-24px" fontIcon="mdi-account-group"></mat-icon>
             <p>Team Users</p>
           </div>
+          @if (canManageRoles) {
           <button mat-stroked-button (click)="fileInput.click()"
             title="Import users from a CSV containing a single column of user IDs">
             Import Users
           </button>
           <input hidden (change)="uploadUsers($event.target.files)" #fileInput type="file" />
+          }
         </mat-toolbar-row>
         <mat-toolbar-row>
           <mat-form-field class="w-100" subscriptSizing="dynamic">

--- a/src/app/components/shared/add-remove-users-dialog/add-remove-users-dialog.component.ts
+++ b/src/app/components/shared/add-remove-users-dialog/add-remove-users-dialog.component.ts
@@ -90,11 +90,15 @@ export class AddRemoveUsersDialogComponent implements OnInit {
   ngOnInit() {
     this.sort.sort(<MatSortable>{ id: 'name', start: 'asc' });
     this.userDataSource.sort = this.sort;
+    this.userDataSource.paginator = this.paginator;
 
     // The team users list is a separate data source with its own paginator
     // and search. Match by user name/id since TeamUser nests the user object.
     this.teamUserDataSource.paginator = this.teamPaginator;
-    this.teamUserDataSource.filterPredicate = (data: TeamUser, filter: string) =>
+    this.teamUserDataSource.filterPredicate = (
+      data: TeamUser,
+      filter: string,
+    ) =>
       (data.user.name ?? '').toLowerCase().includes(filter) ||
       (data.user.id ?? '').toLowerCase().includes(filter);
 
@@ -176,9 +180,7 @@ export class AddRemoveUsersDialogComponent implements OnInit {
           const newAllUsers = allUsers.filter(
             (u) => !tUsers.some((tu) => tu.id === u.id),
           );
-          this.userDataSource = new MatTableDataSource(newAllUsers);
-          this.userDataSource.sort = this.sort;
-          this.userDataSource.paginator = this.paginator;
+          this.userDataSource.data = newAllUsers;
           this.isLoading = false;
           return;
         }
@@ -220,9 +222,7 @@ export class AddRemoveUsersDialogComponent implements OnInit {
                 const index = newAllUsers.findIndex((u) => u.id === tu.user.id);
                 newAllUsers.splice(index, 1);
               });
-              this.userDataSource = new MatTableDataSource(newAllUsers);
-              this.userDataSource.sort = this.sort;
-              this.userDataSource.paginator = this.paginator;
+              this.userDataSource.data = newAllUsers;
               this.isLoading = false;
             },
           ); // forkJoin
@@ -235,9 +235,7 @@ export class AddRemoveUsersDialogComponent implements OnInit {
             const index = newAllUsers.findIndex((u) => u.id === tu.user.id);
             newAllUsers.splice(index, 1);
           });
-          this.userDataSource = new MatTableDataSource(newAllUsers);
-          this.userDataSource.sort = this.sort;
-          this.userDataSource.paginator = this.paginator;
+          this.userDataSource.data = newAllUsers;
           this.isLoading = false;
         }
       }); // getTeamUsers
@@ -316,10 +314,7 @@ export class AddRemoveUsersDialogComponent implements OnInit {
     if (i >= 0) {
       allUsers.splice(i, 1);
     }
-    this.userDataSource = new MatTableDataSource(allUsers);
-    this.userDataSource.sort = this.sort;
-    this.userDataSource.paginator = this.paginator;
-    this.applyFilter(this.filterString);
+    this.userDataSource.data = allUsers;
     this.searchBox.nativeElement.focus();
     this.isBusy = false;
   }
@@ -346,10 +341,7 @@ export class AddRemoveUsersDialogComponent implements OnInit {
             this.teamUserDataSource.data = tUsers;
             const allUsers = this.userDataSource.data.slice(0);
             allUsers.push(tuser.user);
-            this.userDataSource = new MatTableDataSource(allUsers);
-            this.userDataSource.sort = this.sort;
-            this.userDataSource.paginator = this.paginator;
-            this.applyFilter(this.filterString);
+            this.userDataSource.data = allUsers;
             this.searchBox.nativeElement.focus();
             this.isBusy = false;
           },
@@ -439,9 +431,7 @@ export class AddRemoveUsersDialogComponent implements OnInit {
             );
 
             // Update the arrays with the new data
-            this.userDataSource = new MatTableDataSource(lhsNew);
-            this.userDataSource.sort = this.sort;
-            this.userDataSource.paginator = this.paginator;
+            this.userDataSource.data = lhsNew;
             this.teamUserDataSource.data = teamUsers;
           });
       }

--- a/src/app/components/shared/add-remove-users-dialog/add-remove-users-dialog.component.ts
+++ b/src/app/components/shared/add-remove-users-dialog/add-remove-users-dialog.component.ts
@@ -40,8 +40,17 @@ export class AddRemoveUsersDialogComponent implements OnInit {
   public title: string;
   public team: Team;
 
+  // When false, the dialog runs in a restricted mode for users who only have
+  // ManageTeam (not ManageView): the per-user Role column is hidden and team
+  // memberships are not fetched, since those endpoints require ManageView.
+  public canManageRoles = true;
+
   public displayedUserColumns: string[] = ['name', 'id'];
-  public displayedTeamColumns: string[] = ['name', 'teamMembership', 'user'];
+  public get displayedTeamColumns(): string[] {
+    return this.canManageRoles
+      ? ['name', 'teamMembership', 'user']
+      : ['name', 'user'];
+  }
   public userDataSource = new MatTableDataSource<User>(new Array<User>());
   public teamUserDataSource = new MatTableDataSource<TeamUser>(
     new Array<TeamUser>(),
@@ -157,6 +166,23 @@ export class AddRemoveUsersDialogComponent implements OnInit {
           return this.compare(a.name, b.name, true);
         });
 
+        // Restricted mode (ManageTeam only): role management requires reading and
+        // editing team memberships, which need ManageView. Build the team-user
+        // list directly from getTeamUsers with no membership and skip those calls.
+        if (!this.canManageRoles) {
+          this.teamUserDataSource.data = tUsers.map(
+            (us) => new TeamUser(us.name, us, null),
+          );
+          const newAllUsers = allUsers.filter(
+            (u) => !tUsers.some((tu) => tu.id === u.id),
+          );
+          this.userDataSource = new MatTableDataSource(newAllUsers);
+          this.userDataSource.sort = this.sort;
+          this.userDataSource.paginator = this.paginator;
+          this.isLoading = false;
+          return;
+        }
+
         if (tUsers.length > 0) {
           const newTeamUsers = new Array<TeamUser>();
           // The following gets kind of crazy.  Because observables are non-blocking, an array
@@ -240,33 +266,62 @@ export class AddRemoveUsersDialogComponent implements OnInit {
     );
     if (index === -1) {
       this.isBusy = true;
-      this.userService.addUserToTeam(this.team.id, user.id).subscribe(() => {
-        const tUsers = this.teamUserDataSource.data.slice(0);
+      this.userService.addUserToTeam(this.team.id, user.id).subscribe({
+        next: () => {
+          // In restricted mode we cannot read team memberships, so add the user
+          // with a null membership rather than fetching one.
+          if (!this.canManageRoles) {
+            this.addTeamUserToTable(new TeamUser(user.name, user, null));
+            return;
+          }
 
-        this.teamMembershipService
-          .getTeamMemberships(user.id, this.team.viewId)
-          .subscribe((tmbs) => {
-            const teamMembership = tmbs.find(
-              (tmb) => tmb.teamId === this.team.id,
-            );
-            const tUser = new TeamUser(user.name, user, teamMembership);
-            tUsers.push(tUser);
-            tUsers.sort((a, b) => {
-              return this.compare(a.user.name, b.user.name, true);
+          this.teamMembershipService
+            .getTeamMemberships(user.id, this.team.viewId)
+            .subscribe({
+              next: (tmbs) => {
+                const teamMembership = tmbs.find(
+                  (tmb) => tmb.teamId === this.team.id,
+                );
+                this.addTeamUserToTable(
+                  new TeamUser(user.name, user, teamMembership),
+                );
+              },
+              error: (err) => {
+                console.error('Error fetching team membership: ', err);
+                this.isBusy = false;
+              },
             });
-            this.teamUserDataSource.data = tUsers;
-            const allUsers = this.userDataSource.data.slice(0);
-            const i = allUsers.findIndex((u) => u.id === user.id);
-            allUsers.splice(i, 1);
-            this.userDataSource = new MatTableDataSource(allUsers);
-            this.userDataSource.sort = this.sort;
-            this.userDataSource.paginator = this.paginator;
-            this.applyFilter(this.filterString);
-            this.searchBox.nativeElement.focus();
-            this.isBusy = false;
-          });
+        },
+        error: (err) => {
+          console.error('Error adding user to team: ', err);
+          this.isBusy = false;
+        },
       });
     }
+  }
+
+  /**
+   * Adds a TeamUser to the team-users table and removes them from the all-users table.
+   * @param tUser The newly added team user
+   */
+  private addTeamUserToTable(tUser: TeamUser): void {
+    const tUsers = this.teamUserDataSource.data.slice(0);
+    tUsers.push(tUser);
+    tUsers.sort((a, b) => {
+      return this.compare(a.user.name, b.user.name, true);
+    });
+    this.teamUserDataSource.data = tUsers;
+    const allUsers = this.userDataSource.data.slice(0);
+    const i = allUsers.findIndex((u) => u.id === tUser.user.id);
+    if (i >= 0) {
+      allUsers.splice(i, 1);
+    }
+    this.userDataSource = new MatTableDataSource(allUsers);
+    this.userDataSource.sort = this.sort;
+    this.userDataSource.paginator = this.paginator;
+    this.applyFilter(this.filterString);
+    this.searchBox.nativeElement.focus();
+    this.isBusy = false;
   }
 
   /**
@@ -284,23 +339,32 @@ export class AddRemoveUsersDialogComponent implements OnInit {
       this.isBusy = true;
       this.userService
         .removeUserFromTeam(this.team.id, tuser.user.id)
-        .subscribe(() => {
-          const tUsers = this.teamUserDataSource.data.slice(0);
-          tUsers.splice(index, 1);
-          this.teamUserDataSource.data = tUsers;
-          const allUsers = this.userDataSource.data.slice(0);
-          allUsers.push(tuser.user);
-          this.userDataSource = new MatTableDataSource(allUsers);
-          this.userDataSource.sort = this.sort;
-          this.userDataSource.paginator = this.paginator;
-          this.applyFilter(this.filterString);
-          this.searchBox.nativeElement.focus();
-          this.isBusy = false;
+        .subscribe({
+          next: () => {
+            const tUsers = this.teamUserDataSource.data.slice(0);
+            tUsers.splice(index, 1);
+            this.teamUserDataSource.data = tUsers;
+            const allUsers = this.userDataSource.data.slice(0);
+            allUsers.push(tuser.user);
+            this.userDataSource = new MatTableDataSource(allUsers);
+            this.userDataSource.sort = this.sort;
+            this.userDataSource.paginator = this.paginator;
+            this.applyFilter(this.filterString);
+            this.searchBox.nativeElement.focus();
+            this.isBusy = false;
+          },
+          error: (err) => {
+            console.error('Error removing user from team: ', err);
+            this.isBusy = false;
+          },
         });
     }
   }
 
   updateMembership(teamUser: TeamUser): void {
+    if (!this.canManageRoles || !teamUser.teamMembership) {
+      return;
+    }
     console.log(
       'Update Team Membership: ' +
         teamUser.name +

--- a/src/app/components/shared/top-bar/topbar.component.html
+++ b/src/app/components/shared/top-bar/topbar.component.html
@@ -50,6 +50,11 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           Edit View
         </a>
         }
+        @if (team && (showManageTeams$ | async)) {
+        <button mat-menu-item (click)="openManageTeams()">
+          Manage Teams
+        </button>
+        }
         @if ((showAdministration$ | async) && topbarView === 'player-admin') {
         <a [routerLink]="['/']" mat-menu-item>
           Exit Administration

--- a/src/app/components/shared/top-bar/topbar.component.ts
+++ b/src/app/components/shared/top-bar/topbar.component.ts
@@ -111,6 +111,7 @@ export class TopbarComponent implements OnInit, OnDestroy {
       data: { viewId: this.viewId },
       maxWidth: '100vw',
       width: 'auto',
+      autoFocus: 'dialog',
     });
   }
 

--- a/src/app/components/shared/top-bar/topbar.component.ts
+++ b/src/app/components/shared/top-bar/topbar.component.ts
@@ -15,9 +15,10 @@ import {
 import { MatDialog } from '@angular/material/dialog';
 import { ComnAuthQuery, ComnAuthService, Theme } from '@cmusei/crucible-common';
 import { User as AuthUser } from 'oidc-client-ts';
-import { Observable, Subject } from 'rxjs';
-import { filter, takeUntil } from 'rxjs/operators';
+import { combineLatest, Observable, Subject } from 'rxjs';
+import { filter, map, takeUntil } from 'rxjs/operators';
 import { LoggedInUserService } from '../../../services/logged-in-user/logged-in-user.service';
+import { ManageTeamsComponent } from '../../player/manage-teams/manage-teams.component';
 import { UserPresenceComponent } from '../../player/user-presence-page/user-presence/user-presence.component';
 import { TopbarView } from './topbar.models';
 import { Router } from '@angular/router';
@@ -61,6 +62,13 @@ export class TopbarComponent implements OnInit, OnDestroy {
     ViewPermission.ManageView,
   );
 
+  // Show "Manage Teams" to users who can manage at least one Team but do not have
+  // full Edit View access (those users use "Edit View" instead).
+  showManageTeams$ = combineLatest([
+    this.permissionsService.canManageAnyTeam$,
+    this.showEditView$,
+  ]).pipe(map(([canManageTeam, canEditView]) => canManageTeam && !canEditView));
+
   @ViewChild('userPresenceDialog')
   userPresenceDialog: TemplateRef<UserPresenceComponent>;
 
@@ -96,6 +104,14 @@ export class TopbarComponent implements OnInit, OnDestroy {
   editFn(event) {
     event.preventDefault();
     this.editView.emit(event);
+  }
+
+  openManageTeams() {
+    this.dialog.open(ManageTeamsComponent, {
+      data: { viewId: this.viewId },
+      maxWidth: '100vw',
+      width: 'auto',
+    });
   }
 
   editFnNewTab(event) {

--- a/src/app/services/dialog/dialog.service.ts
+++ b/src/app/services/dialog/dialog.service.ts
@@ -96,13 +96,15 @@ export class DialogService {
   public addRemoveUsersToTeam(
     title: string,
     team: Team,
-    configData?: any
+    configData?: any,
+    canManageRoles = true
   ): Observable<boolean> {
     const dialogRef = this.dialog.open(
       AddRemoveUsersDialogComponent,
       configData || {}
     );
     dialogRef.componentInstance.title = title;
+    dialogRef.componentInstance.canManageRoles = canManageRoles;
     dialogRef.componentInstance.loadTeam(team);
     return dialogRef.afterClosed();
   }

--- a/src/app/services/permissions/user-permissions.service.ts
+++ b/src/app/services/permissions/user-permissions.service.ts
@@ -57,6 +57,32 @@ export class UserPermissionsService {
       .pipe(tap((x) => this.teamPermissionsSubject.next(x)));
   }
 
+  // Team ids the user can manage (claim includes the ManageTeam permission). A
+  // ManageTeam grant requires team membership, so these claims reliably enumerate
+  // the teams a non-ManageView user is allowed to manage.
+  public manageableTeamIds$ = this.teamPermissions$.pipe(
+    map((claims) => this.getManageableTeamIds(claims))
+  );
+
+  // Pure helper: team ids from the given claims that include the ManageTeam
+  // permission. Shared with consumers that read freshly-loaded claims directly
+  // (e.g. the Manage Teams dialog) so the filter logic is not duplicated.
+  public getManageableTeamIds(claims: TeamPermissionsClaim[]): string[] {
+    return claims
+      .filter((claim) =>
+        this.toTeamPermissions(claim.permissionValues ?? []).includes(
+          TeamPermission.ManageTeam
+        )
+      )
+      .map((claim) => claim.teamId)
+      .filter((teamId): teamId is string => teamId != null);
+  }
+
+  // True when the user can manage at least one team.
+  public canManageAnyTeam$ = this.manageableTeamIds$.pipe(
+    map((ids) => ids.length > 0)
+  );
+
   can(
     permission: SystemPermission,
     teamId?: string,


### PR DESCRIPTION
## Manage Teams for team managers

Users who manage one or more teams within a View can now add and remove team members directly — without needing full **Manage View** access.

A new **Manage Teams** option appears in the user menu for these users. It opens a dialog listing the teams they manage, each showing its current member count, with a one-click path to add or remove users. The dialog opens in place, so closing it returns you right to your View.

### What's new
- **Manage Teams menu item** for users with team-level management permissions (users who already have full Manage View access continue to use Edit View as before).
- **Add/remove team members** from a focused dialog scoped to just the teams you manage.
- Member-count badges **update live** as you add or remove users, and the team you're working in stays expanded.