### PR TITLE
Bump crucible-common to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser": "^21.2.1",
         "@angular/platform-browser-dynamic": "^21.2.1",
         "@angular/router": "^21.2.1",
-        "@cmusei/crucible-common": "0.7.2",
+        "@cmusei/crucible-common": "0.7.3",
         "@datorama/akita": "^8.0.1",
         "@datorama/akita-ng-router-store": "^8.0.0",
         "@material/material-color-utilities": "^0.4.0",
@@ -2735,8 +2735,8 @@
       }
     },
     "node_modules/@cmusei/crucible-common": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.2.tgz",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.3.tgz",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-browser": "^21.2.1",
     "@angular/platform-browser-dynamic": "^21.2.1",
     "@angular/router": "^21.2.1",
-    "@cmusei/crucible-common": "0.7.2",
+    "@cmusei/crucible-common": "0.7.3",
     "@datorama/akita": "^8.0.1",
     "@datorama/akita-ng-router-store": "^8.0.0",
     "@material/material-color-utilities": "^0.4.0",

--- a/src/app/components/admin-app/admin-roles/roles/roles.component.ts
+++ b/src/app/components/admin-app/admin-roles/roles/roles.component.ts
@@ -113,7 +113,7 @@ export class SystemRolesComponent implements OnInit, OnDestroy {
       .name('Create New Role?', '', { nameValue: '' })
       .pipe(take(1))
       .subscribe((result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           this.roleService.createRole({ name: result.nameValue }).subscribe();
         }
       });
@@ -124,7 +124,7 @@ export class SystemRolesComponent implements OnInit, OnDestroy {
       .name('Create New Permission?', '', { nameValue: '' })
       .pipe(take(1))
       .subscribe((result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           this.permissionService
             .createPermission({ name: result.nameValue })
             .subscribe();
@@ -137,7 +137,7 @@ export class SystemRolesComponent implements OnInit, OnDestroy {
       .name('Rename Role?', '', { nameValue: role.name })
       .pipe(take(1))
       .subscribe((result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           role.name = result.nameValue;
           this.roleService.editRole(role).subscribe();
         }

--- a/src/app/components/admin-app/admin-roles/team-roles/team-roles.component.ts
+++ b/src/app/components/admin-app/admin-roles/team-roles/team-roles.component.ts
@@ -122,7 +122,7 @@ export class TeamRolesComponent implements OnInit, OnDestroy {
       .name('Create New Team Role?', '', { nameValue: '' })
       .pipe(take(1))
       .subscribe((result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           this.roleService.createRole({ name: result.nameValue }).subscribe();
         }
       });
@@ -133,7 +133,7 @@ export class TeamRolesComponent implements OnInit, OnDestroy {
       .name('Create New Team Permission?', '', { nameValue: '' })
       .pipe(take(1))
       .subscribe((result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           this.permissionService
             .createTeamPermission({ name: result.nameValue })
             .subscribe();
@@ -146,7 +146,7 @@ export class TeamRolesComponent implements OnInit, OnDestroy {
       .name('Rename Role?', '', { nameValue: role.name })
       .pipe(take(1))
       .subscribe((result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           role.name = result.nameValue;
           this.roleService.editRole(role.id, role).subscribe();
         }

--- a/src/app/components/admin-app/app-admin-subscription-search/edit-subscription/edit-subscription.component.html
+++ b/src/app/components/admin-app/app-admin-subscription-search/edit-subscription/edit-subscription.component.html
@@ -6,7 +6,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   [dialogTitle]="currentSub == null ? 'Add Subscription' : 'Edit Subscription'"
   [form]="form"
   submitLabel="Save"
-  (cancel)="onCancel()"
   (submit)="onSubmit()"
 >
   <div crucibleDialogContent [formGroup]="form" class="d-flex flex-column">

--- a/src/app/components/admin-app/app-admin-subscription-search/edit-subscription/edit-subscription.component.ts
+++ b/src/app/components/admin-app/app-admin-subscription-search/edit-subscription/edit-subscription.component.ts
@@ -82,10 +82,6 @@ export class EditSubscriptionComponent implements OnInit {
     }
   }
 
-  onCancel() {
-    this.dialogRef.close(false);
-  }
-
   editSecretChanged(change: MatCheckboxChange) {
     const control = this.form.get('clientSecret');
 

--- a/src/app/components/home-app/view-list/view-list.component.ts
+++ b/src/app/components/home-app/view-list/view-list.component.ts
@@ -102,7 +102,7 @@ export class ViewListComponent implements OnInit, AfterViewInit, OnDestroy {
       })
       .pipe(take(1))
       .subscribe((result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           this.viewsService
             .createView({
               name: result.nameValue,

--- a/src/app/components/shared/edit-file-dialog/edit-file-dialog.component.html
+++ b/src/app/components/shared/edit-file-dialog/edit-file-dialog.component.html
@@ -9,7 +9,6 @@ DM20-0181 -->
   dialogTitle="Edit File"
   [form]="form"
   submitLabel="Save"
-  (cancel)="cancel()"
   (submit)="submit()"
 >
   <div crucibleDialogContent [formGroup]="form">

--- a/src/app/components/shared/edit-file-dialog/edit-file-dialog.component.ts
+++ b/src/app/components/shared/edit-file-dialog/edit-file-dialog.component.ts
@@ -66,10 +66,4 @@ export class EditFileDialogComponent implements OnInit {
     );
   }
 
-  cancel() {
-    this.dialogRef.close({
-      name: this.oldName,
-      teams: this.oldTeams,
-    });
-  }
 }

--- a/src/app/components/shared/name-dialog/name-dialog.component.html
+++ b/src/app/components/shared/name-dialog/name-dialog.component.html
@@ -9,7 +9,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   submitLabel="Save"
   [submitDisabled]="!form.valid || !form.dirty"
   [guardUnsavedWork]="true"
-  (cancel)="onCancel()"
   (submit)="onClick()"
 >
   <div crucibleDialogContent [formGroup]="form">

--- a/src/app/components/shared/name-dialog/name-dialog.component.ts
+++ b/src/app/components/shared/name-dialog/name-dialog.component.ts
@@ -57,15 +57,6 @@ export class NameDialogComponent {
     if (this.data.showDescription) {
       this.data.descriptionValue = this.form?.get('description')?.value;
     }
-    this.data.wasCancelled = false;
-    this.dialogRef.close(this.data);
-  }
-
-  onCancel(): void {
-    this.data.artifacts && this.data.artifacts.length > 0
-      ? (this.data.removeArtifacts = this.removeArtifacts)
-      : (this.data.removeArtifacts = false);
-    this.data.wasCancelled = true;
     this.dialogRef.close(this.data);
   }
 }


### PR DESCRIPTION
## Summary

Bumps `@cmusei/crucible-common` from `0.7.2` to `0.7.3`.

**What 0.7.3 provides:**
- **Cancel now closes `crucible-dialog` via the injected `MatDialogRef` instead of a bare `mat-dialog-close` attribute.** Previously the bare attribute made Angular close with `''` (empty string) rather than `undefined`, which slipped past `result ?? {...}` and `!result.wasCancelled` guards — a cancelled dialog could be treated as a real result.
- **Loading-state layout fix**: the primary button's label and `<mat-progress-spinner>` are now wrapped and laid out as one centered inline-flex row, fixing the spinner dropping to its own line beneath the label text while `loading` is set.

**Impact on player.ui:**
- `NameDialogComponent.onCancel()` (with its `wasCancelled` payload), `EditSubscriptionComponent.onCancel()`, and `EditFileDialogComponent.cancel()` are all now redundant — they existed solely to close the dialog explicitly to compensate for the old `''`-on-cancel behavior — and have been removed along with their `(cancel)` bindings.
- `SystemRolesComponent`, `TeamRolesComponent`, and `ViewListComponent` now guard their name-dialog subscriptions with a simple truthy check (`if (result)`) instead of `if (!result.wasCancelled)`, since cancellation now reliably emits `undefined`.
- No consumer-visible behavior change other than fixing the same class of "cancel treated as submit" bug this crucible-common release targets — cancelling create/rename dialogs for roles, permissions, views, subscriptions, and file edits now correctly no-ops.
